### PR TITLE
If the request to the local ip fails the loop can proceed

### DIFF
--- a/myjd_api/providers/myjdapi.py
+++ b/myjd_api/providers/myjdapi.py
@@ -773,8 +773,12 @@ class Jddevice:
                     api = "http://" + connection_ip + ":" + str(
                         connection["port"])
                     # if self.myjd.request_api("/device/ping", "POST", None, self.__action_url(), api):
-                    response = self.myjd.request_api(path, http_action, params,
+                    try:
+                        response = self.myjd.request_api(path, http_action, params,
                                                      action_url, api)
+                    except:
+                        continue
+
                     if response is not None:
                         # This connection worked so we push it to the top of the list.
                         self.__direct_connection_info.remove(conn)


### PR DESCRIPTION
It is a rather easy workaround to get rid of the issue if the connection check of the local IPs runs in to a timeout using the urlopen library.
It will have a rather long response time till the direct connection order is cleaned up. But on my test with two timeouts it worked still fine even in the opening client.